### PR TITLE
Déplace db/images/files vers userData + ajoute electron-log

### DIFF
--- a/app.js
+++ b/app.js
@@ -4,6 +4,7 @@ const path = require("path");
 const cors = require("cors");
 const zmanRoutes = require("./routes/zmanim");
 const adminRoutes = require("./routes/admin");
+const { DB_DIR, IMAGES_DIR, FILES_DIR } = require("./paths");
 
 const fs = require("fs");
 
@@ -16,9 +17,9 @@ app.use(express.urlencoded({ extended: true }));
 
 app.use("/views", express.static(path.join(ROOT, "views")));
 app.use("/public", express.static(path.join(ROOT, "public")));
-app.use("/files", express.static(path.join(ROOT, "files")));
-app.use("/images", express.static(path.join(ROOT, "images")));
-app.use("/db", express.static(path.join(ROOT, "db")));
+app.use("/files", express.static(FILES_DIR));
+app.use("/images", express.static(IMAGES_DIR));
+app.use("/db", express.static(DB_DIR));
 
 app.use("/admin", adminRoutes);
 app.use("/api/zmanim", zmanRoutes);

--- a/controllers/admin.js
+++ b/controllers/admin.js
@@ -1,5 +1,6 @@
 const fs = require("fs");
 const path = require("path");
+const { DB_DIR } = require("../paths");
 
 const ROOT = path.join(__dirname, "..");
 
@@ -10,7 +11,7 @@ exports.afficheHtml = (req, res, next) => {
 exports.saveZmanChol = (req, res, next) => {
   let zmanChol = req.body;
   zmanChol = JSON.stringify(zmanChol, null, 2);
-  fs.writeFileSync(path.join(ROOT, "db", "zmanChol.txt"), zmanChol);
+  fs.writeFileSync(path.join(DB_DIR, "zmanChol.txt"), zmanChol);
   res.json({
     message: "Les changements ont bien été pris en compte",
     zmanChol,
@@ -20,7 +21,7 @@ exports.saveZmanChol = (req, res, next) => {
 exports.saveZmanShbt = (req, res, next) => {
   let zmanShbt = req.body;
   zmanShbt = JSON.stringify(zmanShbt, null, 2);
-  fs.writeFileSync(path.join(ROOT, "db", "zmanShbt.txt"), zmanShbt);
+  fs.writeFileSync(path.join(DB_DIR, "zmanShbt.txt"), zmanShbt);
   res.json({
     message: "Les changements ont bien été pris en compte",
     zmanShbt,
@@ -37,18 +38,18 @@ exports.saveCheckbox = (req, res, next) => {
   let checkbox = req.body;
   console.log(checkbox);
   checkbox = JSON.stringify(checkbox, null, 2);
-  fs.writeFileSync(path.join(ROOT, "db", "checkbox.txt"), checkbox);
+  fs.writeFileSync(path.join(DB_DIR, "checkbox.txt"), checkbox);
   res.json({ message: "Successfully uploaded files", body: req.body });
 };
 
 exports.saveReload = (req, res, next) => {
-  let reloadDB = fs.readFileSync(path.join(ROOT, "db", "reload.txt"));
+  let reloadDB = fs.readFileSync(path.join(DB_DIR, "reload.txt"));
   reloadDB = JSON.parse(reloadDB);
   console.log("reloadDB", reloadDB);
   let checkReload = reloadDB.reload;
   let inverse = { reload: !checkReload };
   console.log("inverse", inverse);
   inverse = JSON.stringify(inverse, null, 2);
-  fs.writeFileSync(path.join(ROOT, "db", "reload.txt"), inverse);
+  fs.writeFileSync(path.join(DB_DIR, "reload.txt"), inverse);
   res.json({ message: "Successfully reload", inverse });
 };

--- a/controllers/zmanim.js
+++ b/controllers/zmanim.js
@@ -2,8 +2,7 @@ const { zmanJerusalem } = require("../cities/zmanim");
 const { eventsByDate } = require("../hebcal3");
 const fs = require("fs");
 const path = require("path");
-
-const ROOT = path.join(__dirname, "..");
+const { DB_DIR } = require("../paths");
 
 exports.envoyerZmanDuJour = (req, res, next) => {
   res.json(zmanJerusalem());
@@ -14,31 +13,31 @@ exports.envoyerInfoDuJour = (req, res, next) => {
 };
 
 exports.sendZmanChol = (req, res, next) => {
-  let zmanChol = fs.readFileSync(path.join(ROOT, "db", "zmanChol.txt"));
+  let zmanChol = fs.readFileSync(path.join(DB_DIR, "zmanChol.txt"));
   zmanChol = JSON.parse(zmanChol);
   res.json(zmanChol);
 };
 
 exports.sendZmanShbt = (req, res, next) => {
-  let zmanShbt = fs.readFileSync(path.join(ROOT, "db", "zmanShbt.txt"));
+  let zmanShbt = fs.readFileSync(path.join(DB_DIR, "zmanShbt.txt"));
   zmanShbt = JSON.parse(zmanShbt);
   res.json(zmanShbt);
 };
 
 exports.sendReload = (req, res, next) => {
-  let reloadDB = fs.readFileSync(path.join(ROOT, "db", "reload.txt"));
+  let reloadDB = fs.readFileSync(path.join(DB_DIR, "reload.txt"));
   reloadDB = JSON.parse(reloadDB);
   res.json(reloadDB);
 };
 
 exports.sendCheckbox = (req, res, next) => {
-  let checkbox = fs.readFileSync(path.join(ROOT, "db", "checkbox.txt"));
+  let checkbox = fs.readFileSync(path.join(DB_DIR, "checkbox.txt"));
   checkbox = JSON.parse(checkbox);
   res.json(checkbox);
 };
 
 exports.sendNameOfImages = (req, res, next) => {
-  let nameOfImages = fs.readFileSync(path.join(ROOT, "db", "images-display.txt"));
+  let nameOfImages = fs.readFileSync(path.join(DB_DIR, "images-display.txt"));
   nameOfImages = JSON.parse(nameOfImages);
   res.json(nameOfImages);
 };

--- a/main.js
+++ b/main.js
@@ -1,60 +1,72 @@
-const {app, BrowserWindow} = require('electron');
-require('./app');
+const { app, BrowserWindow } = require("electron");
+const log = require("electron-log");
 
-const server = require('./server');
+// Redirige console.log / console.error / etc. vers userData/logs/main.log,
+// en plus du terminal quand il y en a un.
+Object.assign(console, log.functions);
+
+// Rend le chemin userData visible au serveur Express (chargé ci-dessous).
+// Doit être positionné AVANT le require('./server'), sinon paths.js retombera
+// sur les dossiers du bundle (lecture seule en prod).
+process.env.MENOUCHAT_USER_DATA = app.getPath("userData");
+
+// Amorce userData/db, userData/images, userData/files avec les fichiers
+// par défaut du bundle au premier lancement.
+const { seedUserData } = require("./paths");
+seedUserData();
+
+require("./app");
+const server = require("./server");
 
 let mainWindow;
 
-function createWindow () {
-
+function createWindow() {
   mainWindow = new BrowserWindow({
     width: 1200,
     height: 800,
-    icon: './public/clock.ico',
+    icon: "./public/clock.ico",
     webPreferences: {
-      nodeIntegration: true
-    }
-  })
+      nodeIntegration: true,
+    },
+  });
 
   secondWindow = new BrowserWindow({
     width: 540,
     height: 960,
     frame: false,
     webPreferences: {
-      nodeIntegration: true
-    }
-  })
+      nodeIntegration: true,
+    },
+  });
 
-  secondWindow.loadURL('http://localhost:3000/shoul')
-  secondWindow.on('closed', function () {
-    secondWindow = null
-  })
+  secondWindow.loadURL("http://localhost:3000/shoul");
+  secondWindow.on("closed", function () {
+    secondWindow = null;
+  });
 
-  mainWindow.loadURL('http://localhost:3000')
-  mainWindow.on('closed', function () {
-    mainWindow = null
-  })
-
-
+  mainWindow.loadURL("http://localhost:3000");
+  mainWindow.on("closed", function () {
+    mainWindow = null;
+  });
 }
 
-app.commandLine.appendSwitch('lang', 'fr');
+app.commandLine.appendSwitch("lang", "fr");
 
-app.on('ready', createWindow)
+app.on("ready", createWindow);
 
-app.on('resize', function(e,x,y){
+app.on("resize", function (e, x, y) {
   mainWindow.setSize(x, y);
   secondWindow.setSize(x, y);
 });
 
-app.on('window-all-closed', function () {
-  if (process.platform !== 'darwin') {
-    app.quit()
+app.on("window-all-closed", function () {
+  if (process.platform !== "darwin") {
+    app.quit();
   }
-})
+});
 
-app.on('activate', function () {
+app.on("activate", function () {
   if (mainWindow === null) {
-    createWindow()
+    createWindow();
   }
-})
+});

--- a/middleware/gmshell-config.js
+++ b/middleware/gmshell-config.js
@@ -1,8 +1,7 @@
 const fs = require("fs");
 const path = require("path");
 const { createCanvas, loadImage } = require("@napi-rs/canvas");
-
-const ROOT = path.join(__dirname, "..");
+const { DB_DIR, IMAGES_DIR, FILES_DIR } = require("../paths");
 
 async function convertToJpg(inputPath, outputPath, mimetype) {
   if (mimetype === "application/pdf") {
@@ -49,8 +48,8 @@ module.exports = (req, res, next) => {
   const numberOfImage = req.body.numberOfImage;
   const oldPath = req.files[0].path;
   const mimetype = req.files[0].mimetype;
-  const newPath = path.join(ROOT, "files", nameOfFile);
-  const outputJpg = path.join(ROOT, "images", `imageAffiche${numberOfImage}.jpg`);
+  const newPath = path.join(FILES_DIR, nameOfFile);
+  const outputJpg = path.join(IMAGES_DIR, `imageAffiche${numberOfImage}.jpg`);
 
   convertToJpg(oldPath, outputJpg, mimetype)
     .then(() => {
@@ -59,7 +58,7 @@ module.exports = (req, res, next) => {
         if (err) throw err;
         console.log("fichier renommé dans './files'");
 
-        const dbPath = path.join(ROOT, "db", "images-display.txt");
+        const dbPath = path.join(DB_DIR, "images-display.txt");
         let objectImage = fs.readFileSync(dbPath);
         objectImage = JSON.parse(objectImage);
         objectImage.imageDisplay[numberOfImage - 1] = nameOfFile;

--- a/middleware/multer-config.js
+++ b/middleware/multer-config.js
@@ -1,5 +1,5 @@
 const multer = require("multer");
-const path = require("path");
+const { FILES_DIR } = require("../paths");
 
 const MIME_TYPES = {
   "image/jpg": "jpg",
@@ -10,7 +10,7 @@ const MIME_TYPES = {
 
 const storage = multer.diskStorage({
   destination: (req, file, callback) => {
-    callback(null, path.join(__dirname, "..", "files"));
+    callback(null, FILES_DIR);
   },
   filename: (req, file, callback) => {
     // console.log('req.files', req.files);

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,13 +10,16 @@
       "license": "ISC",
       "dependencies": {
         "@hebcal/core": "^3.42.0",
+        "@napi-rs/canvas": "^0.1.98",
         "cors": "^2.8.5",
         "dotenv": "^16.0.1",
+        "electron-log": "^5.4.3",
         "electron-squirrel-startup": "^1.0.0",
         "express": "^4.18.1",
         "kosher-zmanim": "^0.8.2",
         "multer": "^1.4.5-lts.1",
-        "nodemon": "^2.0.16"
+        "nodemon": "^2.0.16",
+        "pdfjs-dist": "^5.6.205"
       },
       "devDependencies": {
         "@electron-forge/cli": "^6.0.0-beta.65",
@@ -2103,6 +2106,255 @@
         "node": ">= 12.13.0"
       }
     },
+    "node_modules/@napi-rs/canvas": {
+      "version": "0.1.99",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas/-/canvas-0.1.99.tgz",
+      "integrity": "sha512-zN4eQlK3eBf7aJBcTHZilpBH3tDekBzPMIWC8r0s94Ecl73XfOyFi4w7yKFMRVUT0lvNQjtOL8YSrwqQj6mZFg==",
+      "license": "MIT",
+      "workspaces": [
+        "e2e/*"
+      ],
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      },
+      "optionalDependencies": {
+        "@napi-rs/canvas-android-arm64": "0.1.99",
+        "@napi-rs/canvas-darwin-arm64": "0.1.99",
+        "@napi-rs/canvas-darwin-x64": "0.1.99",
+        "@napi-rs/canvas-linux-arm-gnueabihf": "0.1.99",
+        "@napi-rs/canvas-linux-arm64-gnu": "0.1.99",
+        "@napi-rs/canvas-linux-arm64-musl": "0.1.99",
+        "@napi-rs/canvas-linux-riscv64-gnu": "0.1.99",
+        "@napi-rs/canvas-linux-x64-gnu": "0.1.99",
+        "@napi-rs/canvas-linux-x64-musl": "0.1.99",
+        "@napi-rs/canvas-win32-arm64-msvc": "0.1.99",
+        "@napi-rs/canvas-win32-x64-msvc": "0.1.99"
+      }
+    },
+    "node_modules/@napi-rs/canvas-android-arm64": {
+      "version": "0.1.99",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-android-arm64/-/canvas-android-arm64-0.1.99.tgz",
+      "integrity": "sha512-9OCRt8VVxA17m32NWZKyNC2qamdaS/SC5CEOIQwFngRq0DIeVm4PDal+6Ljnhqm2whZiC63DNuKZ4xSp2nbj9w==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      }
+    },
+    "node_modules/@napi-rs/canvas-darwin-arm64": {
+      "version": "0.1.99",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-darwin-arm64/-/canvas-darwin-arm64-0.1.99.tgz",
+      "integrity": "sha512-lupMDMy1+H38dhyCcLirOKKVUyzzlxi7j7rGPLI3vViMHOoPjcXO1b10ivy+ad+q6MiwHfoLjKTCoLke5ySOBg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      }
+    },
+    "node_modules/@napi-rs/canvas-darwin-x64": {
+      "version": "0.1.99",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-darwin-x64/-/canvas-darwin-x64-0.1.99.tgz",
+      "integrity": "sha512-fdz02t4w8n6Ii/rYhWig6STb/zcTmCC/6YZTGmjoDeidDwn9Wf0ukQVynhCPEs29vqUc66wHZKsuIgMs9tycCg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      }
+    },
+    "node_modules/@napi-rs/canvas-linux-arm-gnueabihf": {
+      "version": "0.1.99",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-arm-gnueabihf/-/canvas-linux-arm-gnueabihf-0.1.99.tgz",
+      "integrity": "sha512-w4FwVwlNo00ezeRhfY62IVIyt6G3u8wodkPtiqWc52BUHx+VDBUM2vkS3ogfANaLI7hnf3s6WK4LyZVUjBg1lA==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      }
+    },
+    "node_modules/@napi-rs/canvas-linux-arm64-gnu": {
+      "version": "0.1.99",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-arm64-gnu/-/canvas-linux-arm64-gnu-0.1.99.tgz",
+      "integrity": "sha512-8JvHeexKQ8c7g0q7YJ29NVQwnf1ePghP9ys9ZN0R0qzyqJQ9Uw6N9qnDINArlm3IYHexB7LjzArIfhQiqSDGvQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      }
+    },
+    "node_modules/@napi-rs/canvas-linux-arm64-musl": {
+      "version": "0.1.99",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-arm64-musl/-/canvas-linux-arm64-musl-0.1.99.tgz",
+      "integrity": "sha512-Z+6nyLdJXWzLPVxi4H6g9TJop4DwN3KSgHWto5JCbZV5/uKoVqcSynPs0tGlUHOoWI8S8tEvJspz51GQkvr07w==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      }
+    },
+    "node_modules/@napi-rs/canvas-linux-riscv64-gnu": {
+      "version": "0.1.99",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-riscv64-gnu/-/canvas-linux-riscv64-gnu-0.1.99.tgz",
+      "integrity": "sha512-jAnfOUv4IO1l8Levk5t85oVtEBOXLa07KnIUgWo1CDlPxiqpxS3uBfiE38Lvj/CQgHaNF6Nxk/SaemwLgsVJgw==",
+      "cpu": [
+        "riscv64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      }
+    },
+    "node_modules/@napi-rs/canvas-linux-x64-gnu": {
+      "version": "0.1.99",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-x64-gnu/-/canvas-linux-x64-gnu-0.1.99.tgz",
+      "integrity": "sha512-mIkXw3fGmbYyFjSmfWEvty4jN+rwEOmv0+Dy9bRvvTzLYWCgm3RMgUEQVfAKFw96nIRFnyNZiK83KNQaVVFjng==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      }
+    },
+    "node_modules/@napi-rs/canvas-linux-x64-musl": {
+      "version": "0.1.99",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-x64-musl/-/canvas-linux-x64-musl-0.1.99.tgz",
+      "integrity": "sha512-f3Uz2P0RgrtBHISxZqr6yiYXJlTDyCVBumDacxo+4AmSg7z0HiqYZKGWC/gszq3fbPhyQUya1W2AEteKxT9Y6A==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      }
+    },
+    "node_modules/@napi-rs/canvas-win32-arm64-msvc": {
+      "version": "0.1.99",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-win32-arm64-msvc/-/canvas-win32-arm64-msvc-0.1.99.tgz",
+      "integrity": "sha512-XE6KUkfqRsCNejcoRMiMr3RaUeObxNf6y7dut3hrq2rn7PzfRTZgrjF1F/B2C7FcdgqY/vSHWpQeMuNz1vTNHg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      }
+    },
+    "node_modules/@napi-rs/canvas-win32-x64-msvc": {
+      "version": "0.1.99",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-win32-x64-msvc/-/canvas-win32-x64-msvc-0.1.99.tgz",
+      "integrity": "sha512-plMYGVbc/vmmPF9MtmHbwNk1rL1Aj53vQZt+Gnv1oZn6gmd9jEHHJ0n9Nd2nxa5sKH7TS5IjkCDM6289O0d6PQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      }
+    },
     "node_modules/@nodelib/fs.scandir": {
       "version": "2.1.5",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
@@ -3949,6 +4201,15 @@
       "optional": true,
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/electron-log": {
+      "version": "5.4.3",
+      "resolved": "https://registry.npmjs.org/electron-log/-/electron-log-5.4.3.tgz",
+      "integrity": "sha512-sOUsM3LjZdugatazSQ/XTyNcw8dfvH1SYhXWiJyfYodAAKOZdHs0txPiLDXFzOZbhXgAgshQkshH2ccq0feyLQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14"
       }
     },
     "node_modules/electron-packager": {
@@ -6490,6 +6751,13 @@
         "node": ">=10"
       }
     },
+    "node_modules/node-readable-to-web-readable-stream": {
+      "version": "0.4.2",
+      "resolved": "https://registry.npmjs.org/node-readable-to-web-readable-stream/-/node-readable-to-web-readable-stream-0.4.2.tgz",
+      "integrity": "sha512-/cMZNI34v//jUTrI+UIo4ieHAB5EZRY/+7OmXZgBxaWBMcW2tGdceIw06RFxWxrKZ5Jp3sI2i5TsRo+CBhtVLQ==",
+      "license": "MIT",
+      "optional": true
+    },
     "node_modules/nodemon": {
       "version": "2.0.16",
       "resolved": "https://registry.npmjs.org/nodemon/-/nodemon-2.0.16.tgz",
@@ -6915,6 +7183,19 @@
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/pdfjs-dist": {
+      "version": "5.6.205",
+      "resolved": "https://registry.npmjs.org/pdfjs-dist/-/pdfjs-dist-5.6.205.tgz",
+      "integrity": "sha512-tlUj+2IDa7G1SbvBNN74UHRLJybZDWYom+k6p5KIZl7huBvsA4APi6mKL+zCxd3tLjN5hOOEE9Tv7VdzO88pfg==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=20.19.0 || >=22.13.0 || >=24"
+      },
+      "optionalDependencies": {
+        "@napi-rs/canvas": "^0.1.96",
+        "node-readable-to-web-readable-stream": "^0.4.2"
       }
     },
     "node_modules/pend": {
@@ -10179,6 +10460,90 @@
         "cross-spawn": "^7.0.1"
       }
     },
+    "@napi-rs/canvas": {
+      "version": "0.1.99",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas/-/canvas-0.1.99.tgz",
+      "integrity": "sha512-zN4eQlK3eBf7aJBcTHZilpBH3tDekBzPMIWC8r0s94Ecl73XfOyFi4w7yKFMRVUT0lvNQjtOL8YSrwqQj6mZFg==",
+      "requires": {
+        "@napi-rs/canvas-android-arm64": "0.1.99",
+        "@napi-rs/canvas-darwin-arm64": "0.1.99",
+        "@napi-rs/canvas-darwin-x64": "0.1.99",
+        "@napi-rs/canvas-linux-arm-gnueabihf": "0.1.99",
+        "@napi-rs/canvas-linux-arm64-gnu": "0.1.99",
+        "@napi-rs/canvas-linux-arm64-musl": "0.1.99",
+        "@napi-rs/canvas-linux-riscv64-gnu": "0.1.99",
+        "@napi-rs/canvas-linux-x64-gnu": "0.1.99",
+        "@napi-rs/canvas-linux-x64-musl": "0.1.99",
+        "@napi-rs/canvas-win32-arm64-msvc": "0.1.99",
+        "@napi-rs/canvas-win32-x64-msvc": "0.1.99"
+      }
+    },
+    "@napi-rs/canvas-android-arm64": {
+      "version": "0.1.99",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-android-arm64/-/canvas-android-arm64-0.1.99.tgz",
+      "integrity": "sha512-9OCRt8VVxA17m32NWZKyNC2qamdaS/SC5CEOIQwFngRq0DIeVm4PDal+6Ljnhqm2whZiC63DNuKZ4xSp2nbj9w==",
+      "optional": true
+    },
+    "@napi-rs/canvas-darwin-arm64": {
+      "version": "0.1.99",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-darwin-arm64/-/canvas-darwin-arm64-0.1.99.tgz",
+      "integrity": "sha512-lupMDMy1+H38dhyCcLirOKKVUyzzlxi7j7rGPLI3vViMHOoPjcXO1b10ivy+ad+q6MiwHfoLjKTCoLke5ySOBg==",
+      "optional": true
+    },
+    "@napi-rs/canvas-darwin-x64": {
+      "version": "0.1.99",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-darwin-x64/-/canvas-darwin-x64-0.1.99.tgz",
+      "integrity": "sha512-fdz02t4w8n6Ii/rYhWig6STb/zcTmCC/6YZTGmjoDeidDwn9Wf0ukQVynhCPEs29vqUc66wHZKsuIgMs9tycCg==",
+      "optional": true
+    },
+    "@napi-rs/canvas-linux-arm-gnueabihf": {
+      "version": "0.1.99",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-arm-gnueabihf/-/canvas-linux-arm-gnueabihf-0.1.99.tgz",
+      "integrity": "sha512-w4FwVwlNo00ezeRhfY62IVIyt6G3u8wodkPtiqWc52BUHx+VDBUM2vkS3ogfANaLI7hnf3s6WK4LyZVUjBg1lA==",
+      "optional": true
+    },
+    "@napi-rs/canvas-linux-arm64-gnu": {
+      "version": "0.1.99",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-arm64-gnu/-/canvas-linux-arm64-gnu-0.1.99.tgz",
+      "integrity": "sha512-8JvHeexKQ8c7g0q7YJ29NVQwnf1ePghP9ys9ZN0R0qzyqJQ9Uw6N9qnDINArlm3IYHexB7LjzArIfhQiqSDGvQ==",
+      "optional": true
+    },
+    "@napi-rs/canvas-linux-arm64-musl": {
+      "version": "0.1.99",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-arm64-musl/-/canvas-linux-arm64-musl-0.1.99.tgz",
+      "integrity": "sha512-Z+6nyLdJXWzLPVxi4H6g9TJop4DwN3KSgHWto5JCbZV5/uKoVqcSynPs0tGlUHOoWI8S8tEvJspz51GQkvr07w==",
+      "optional": true
+    },
+    "@napi-rs/canvas-linux-riscv64-gnu": {
+      "version": "0.1.99",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-riscv64-gnu/-/canvas-linux-riscv64-gnu-0.1.99.tgz",
+      "integrity": "sha512-jAnfOUv4IO1l8Levk5t85oVtEBOXLa07KnIUgWo1CDlPxiqpxS3uBfiE38Lvj/CQgHaNF6Nxk/SaemwLgsVJgw==",
+      "optional": true
+    },
+    "@napi-rs/canvas-linux-x64-gnu": {
+      "version": "0.1.99",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-x64-gnu/-/canvas-linux-x64-gnu-0.1.99.tgz",
+      "integrity": "sha512-mIkXw3fGmbYyFjSmfWEvty4jN+rwEOmv0+Dy9bRvvTzLYWCgm3RMgUEQVfAKFw96nIRFnyNZiK83KNQaVVFjng==",
+      "optional": true
+    },
+    "@napi-rs/canvas-linux-x64-musl": {
+      "version": "0.1.99",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-x64-musl/-/canvas-linux-x64-musl-0.1.99.tgz",
+      "integrity": "sha512-f3Uz2P0RgrtBHISxZqr6yiYXJlTDyCVBumDacxo+4AmSg7z0HiqYZKGWC/gszq3fbPhyQUya1W2AEteKxT9Y6A==",
+      "optional": true
+    },
+    "@napi-rs/canvas-win32-arm64-msvc": {
+      "version": "0.1.99",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-win32-arm64-msvc/-/canvas-win32-arm64-msvc-0.1.99.tgz",
+      "integrity": "sha512-XE6KUkfqRsCNejcoRMiMr3RaUeObxNf6y7dut3hrq2rn7PzfRTZgrjF1F/B2C7FcdgqY/vSHWpQeMuNz1vTNHg==",
+      "optional": true
+    },
+    "@napi-rs/canvas-win32-x64-msvc": {
+      "version": "0.1.99",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-win32-x64-msvc/-/canvas-win32-x64-msvc-0.1.99.tgz",
+      "integrity": "sha512-plMYGVbc/vmmPF9MtmHbwNk1rL1Aj53vQZt+Gnv1oZn6gmd9jEHHJ0n9Nd2nxa5sKH7TS5IjkCDM6289O0d6PQ==",
+      "optional": true
+    },
     "@nodelib/fs.scandir": {
       "version": "2.1.5",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
@@ -11525,6 +11890,11 @@
           "optional": true
         }
       }
+    },
+    "electron-log": {
+      "version": "5.4.3",
+      "resolved": "https://registry.npmjs.org/electron-log/-/electron-log-5.4.3.tgz",
+      "integrity": "sha512-sOUsM3LjZdugatazSQ/XTyNcw8dfvH1SYhXWiJyfYodAAKOZdHs0txPiLDXFzOZbhXgAgshQkshH2ccq0feyLQ=="
     },
     "electron-packager": {
       "version": "17.1.2",
@@ -13435,6 +13805,12 @@
         }
       }
     },
+    "node-readable-to-web-readable-stream": {
+      "version": "0.4.2",
+      "resolved": "https://registry.npmjs.org/node-readable-to-web-readable-stream/-/node-readable-to-web-readable-stream-0.4.2.tgz",
+      "integrity": "sha512-/cMZNI34v//jUTrI+UIo4ieHAB5EZRY/+7OmXZgBxaWBMcW2tGdceIw06RFxWxrKZ5Jp3sI2i5TsRo+CBhtVLQ==",
+      "optional": true
+    },
     "nodemon": {
       "version": "2.0.16",
       "resolved": "https://registry.npmjs.org/nodemon/-/nodemon-2.0.16.tgz",
@@ -13743,6 +14119,15 @@
           "integrity": "sha512-udgsAY+fTnvv7kI7aaxbqwWNb0AHiB0qBO89PZKPkoTmGOgdbrHDKD+0B2X4uTfJ/FT1R09r9gTsjUjNJotuog==",
           "dev": true
         }
+      }
+    },
+    "pdfjs-dist": {
+      "version": "5.6.205",
+      "resolved": "https://registry.npmjs.org/pdfjs-dist/-/pdfjs-dist-5.6.205.tgz",
+      "integrity": "sha512-tlUj+2IDa7G1SbvBNN74UHRLJybZDWYom+k6p5KIZl7huBvsA4APi6mKL+zCxd3tLjN5hOOEE9Tv7VdzO88pfg==",
+      "requires": {
+        "@napi-rs/canvas": "^0.1.96",
+        "node-readable-to-web-readable-stream": "^0.4.2"
       }
     },
     "pend": {

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "@napi-rs/canvas": "^0.1.98",
     "cors": "^2.8.5",
     "dotenv": "^16.0.1",
+    "electron-log": "^5.4.3",
     "electron-squirrel-startup": "^1.0.0",
     "express": "^4.18.1",
     "kosher-zmanim": "^0.8.2",
@@ -33,7 +34,9 @@
     "electron": "^19.0.10"
   },
   "pnpm": {
-    "onlyBuiltDependencies": ["electron"]
+    "onlyBuiltDependencies": [
+      "electron"
+    ]
   },
   "config": {
     "forge": {

--- a/paths.js
+++ b/paths.js
@@ -1,0 +1,47 @@
+const fs = require("fs");
+const path = require("path");
+
+// Chemins "d'usine" (livrés avec le code, en lecture seule une fois packagé).
+const BUNDLE_ROOT = __dirname;
+const BUNDLE_DB = path.join(BUNDLE_ROOT, "db");
+const BUNDLE_IMAGES = path.join(BUNDLE_ROOT, "images");
+const BUNDLE_FILES = path.join(BUNDLE_ROOT, "files");
+
+// En prod (Electron packagé), main.js pose MENOUCHAT_USER_DATA avant de charger le serveur.
+// En dev (npm run dev), la variable n'existe pas → on retombe sur les dossiers du repo.
+const userDataRoot = process.env.MENOUCHAT_USER_DATA;
+
+const DB_DIR = userDataRoot ? path.join(userDataRoot, "db") : BUNDLE_DB;
+const IMAGES_DIR = userDataRoot ? path.join(userDataRoot, "images") : BUNDLE_IMAGES;
+const FILES_DIR = userDataRoot ? path.join(userDataRoot, "files") : BUNDLE_FILES;
+
+// Copie récursive d'un dossier source vers une destination si la destination n'existe pas.
+function seedIfMissing(src, dest) {
+  if (fs.existsSync(dest)) return;
+  fs.mkdirSync(dest, { recursive: true });
+  for (const entry of fs.readdirSync(src, { withFileTypes: true })) {
+    const from = path.join(src, entry.name);
+    const to = path.join(dest, entry.name);
+    if (entry.isDirectory()) {
+      seedIfMissing(from, to);
+    } else {
+      fs.copyFileSync(from, to);
+    }
+  }
+}
+
+// À appeler une fois au démarrage de l'app packagée, pour amorcer userData
+// avec les fichiers par défaut livrés dans le bundle.
+function seedUserData() {
+  if (!userDataRoot) return;
+  seedIfMissing(BUNDLE_DB, DB_DIR);
+  seedIfMissing(BUNDLE_IMAGES, IMAGES_DIR);
+  seedIfMissing(BUNDLE_FILES, FILES_DIR);
+}
+
+module.exports = {
+  DB_DIR,
+  IMAGES_DIR,
+  FILES_DIR,
+  seedUserData,
+};


### PR DESCRIPTION
## Contexte

Une fois l'app installée via `.deb`, toute sauvegarde depuis l'admin plantait avec `EACCES: permission denied, open '/usr/lib/menouchat-chalom/resources/app/db/...'`. Normal : le bundle Electron packagé est en lecture seule (`/usr/lib/...` sur Linux, `Program Files` sur Windows), mais le code écrivait dans `db/*.txt` à côté du code.

Deuxième sujet : aucun log backend n'était accessible une fois l'app lancée depuis l'icône (pas de terminal attaché → `console.log` perdu).

## Ce que fait le PR

### 1. Données déplacées vers `app.getPath('userData')`

Nouveau module `paths.js` qui expose `DB_DIR`, `IMAGES_DIR`, `FILES_DIR` :

- **Prod** (Electron packagé) → `~/.config/menouchat-chalom/{db,images,files}/` (Linux) ou l'équivalent Windows/macOS.
- **Dev** (`npm run dev`, sans Electron) → les dossiers du repo comme avant. Rien ne change pour le workflow local.

Le switch se fait via la variable d'env `MENOUCHAT_USER_DATA` positionnée par `main.js` avant le `require('./server')`.

### 2. Seed au premier lancement

`seedUserData()` dans `main.js` copie récursivement `db/`, `images/`, `files/` du bundle vers `userData` si les dossiers cibles n'existent pas. Le bundle reste la "version d'usine" et les données utilisateur sont préservées entre mises à jour de l'app.

### 3. Callers mis à jour

- `controllers/admin.js`, `controllers/zmanim.js` → lecture/écriture via `DB_DIR`
- `middleware/multer-config.js` → uploads dans `FILES_DIR`
- `middleware/gmshell-config.js` → images converties dans `IMAGES_DIR`, `images-display.txt` dans `DB_DIR`
- `app.js` → `express.static` pour `/files`, `/images`, `/db` pointe vers les dossiers user (sinon le front continuerait à afficher les images du bundle)

### 4. Logs persistants avec `electron-log`

Une ligne dans `main.js` suffit :
```js
Object.assign(console, log.functions);
```
→ tous les `console.log` du serveur Express, des contrôleurs, du process main partent désormais dans :
- Linux : `~/.config/menouchat-chalom/logs/main.log`
- Windows : `%APPDATA%\menouchat-chalom\logs\main.log`
- macOS : `~/Library/Logs/menouchat-chalom/main.log`

En dev, les logs continuent d'apparaître dans le terminal comme avant.

## Test plan

- [x] `npm run dev` : le serveur démarre et lit/écrit dans le `db/` du repo (`MENOUCHAT_USER_DATA` non défini → fallback)
- [x] Simulation prod avec `MENOUCHAT_USER_DATA=/tmp/menouchat-test` : seed OK, cycle POST /admin/reload + POST /admin/zman-chol + GET /api/zmanim/* fonctionne, `reload.txt` et `zmanChol.txt` bien écrits dans `/tmp/menouchat-test/db/`
- [ ] À vérifier côté Manou : `npm run make` puis `sudo dpkg -i out/make/deb/x64/menouchat-chalom_*.deb`, lancer l'app, sauvegarder depuis l'admin → plus d'EACCES, et `cat ~/.config/menouchat-chalom/logs/main.log` montre les logs backend.

## Points d'attention

- Si `~/.config/menouchat-chalom/db/` existe déjà (depuis un ancien démarrage `npm start`), le seed **n'écrasera pas** son contenu. C'est voulu : on ne veut pas détruire des données utilisateur. Si le dossier contient des fichiers incomplets/obsolètes, `rm -rf ~/.config/menouchat-chalom/{db,images,files}` force un nouveau seed au prochain lancement.
- Le bug Windows-only mentionné dans `CLAUDE.md` (`gm.exe` dans `gmshell-config.js`) n'est en fait plus là : le code utilise déjà `@napi-rs/canvas` + `pdfjs-dist`, hors scope donc.

https://claude.ai/code/session_019Lfo14HXDFjYenCVAau3Vw