### PR TITLE
Conversion PDF→image déplacée du serveur vers le browser

### DIFF
--- a/app.js
+++ b/app.js
@@ -17,6 +17,7 @@ app.use(express.urlencoded({ extended: true }));
 
 app.use("/views", express.static(path.join(ROOT, "views")));
 app.use("/public", express.static(path.join(ROOT, "public")));
+app.use("/pdfjs", express.static(path.join(ROOT, "node_modules/pdfjs-dist/build")));
 app.use("/files", express.static(FILES_DIR));
 app.use("/images", express.static(IMAGES_DIR));
 app.use("/db", express.static(DB_DIR));

--- a/middleware/gmshell-config.js
+++ b/middleware/gmshell-config.js
@@ -1,74 +1,26 @@
 const fs = require("fs");
 const path = require("path");
-const { createCanvas, loadImage } = require("@napi-rs/canvas");
 const { DB_DIR, IMAGES_DIR, FILES_DIR } = require("../paths");
-
-async function convertToJpg(inputPath, outputPath, mimetype) {
-  if (mimetype === "application/pdf") {
-    const { getDocument } = await import("pdfjs-dist/legacy/build/pdf.mjs");
-
-    const data = new Uint8Array(fs.readFileSync(inputPath));
-    const pdf = await getDocument({ data }).promise;
-    const page = await pdf.getPage(1);
-
-    const scale = 150 / 72; // équivalent -density 150
-    const viewport = page.getViewport({ scale });
-    const canvas = createCanvas(viewport.width, viewport.height);
-    const context = canvas.getContext("2d");
-
-    await page.render({
-      canvasContext: context,
-      viewport,
-      canvasFactory: {
-        create(w, h) {
-          const c = createCanvas(w, h);
-          return { canvas: c, context: c.getContext("2d") };
-        },
-        reset(obj, w, h) {
-          obj.canvas.width = w;
-          obj.canvas.height = h;
-        },
-        destroy() {},
-      },
-    }).promise;
-
-    fs.writeFileSync(outputPath, canvas.toBuffer("image/jpeg", { quality: 1 }));
-  } else {
-    // PNG ou JPG : chargement direct puis export en JPEG
-    const img = await loadImage(inputPath);
-    const canvas = createCanvas(img.width, img.height);
-    const ctx = canvas.getContext("2d");
-    ctx.drawImage(img, 0, 0);
-    fs.writeFileSync(outputPath, canvas.toBuffer("image/jpeg", { quality: 1 }));
-  }
-}
 
 module.exports = (req, res, next) => {
   const nameOfFile = req.body.nameOfFile;
   const numberOfImage = req.body.numberOfImage;
-  const oldPath = req.files[0].path;
-  const mimetype = req.files[0].mimetype;
-  const newPath = path.join(FILES_DIR, nameOfFile);
+  const uploadedPath = req.files[0].path;
   const outputJpg = path.join(IMAGES_DIR, `imageAffiche${numberOfImage}.jpg`);
+  const finalPath = path.join(FILES_DIR, nameOfFile);
 
-  convertToJpg(oldPath, outputJpg, mimetype)
-    .then(() => {
-      console.log(`fichier converti → ${outputJpg}`);
-      fs.rename(oldPath, newPath, (err) => {
-        if (err) throw err;
-        console.log("fichier renommé dans './files'");
+  fs.copyFile(uploadedPath, outputJpg, (copyErr) => {
+    if (copyErr) return res.status(500).json({ error: copyErr.message });
 
-        const dbPath = path.join(DB_DIR, "images-display.txt");
-        let objectImage = fs.readFileSync(dbPath);
-        objectImage = JSON.parse(objectImage);
-        objectImage.imageDisplay[numberOfImage - 1] = nameOfFile;
-        objectImage = JSON.stringify(objectImage, null, 2);
-        fs.writeFileSync(dbPath, objectImage);
-      });
+    fs.rename(uploadedPath, finalPath, (renameErr) => {
+      if (renameErr) return res.status(500).json({ error: renameErr.message });
+
+      const dbPath = path.join(DB_DIR, "images-display.txt");
+      let objectImage = JSON.parse(fs.readFileSync(dbPath));
+      objectImage.imageDisplay[numberOfImage - 1] = nameOfFile;
+      fs.writeFileSync(dbPath, JSON.stringify(objectImage, null, 2));
+
       next();
-    })
-    .catch((error) => {
-      console.log(`erreur conversion : ${error.message}`);
-      res.status(500).json({ error: error.message });
     });
+  });
 };

--- a/middleware/gmshell-config.js
+++ b/middleware/gmshell-config.js
@@ -9,16 +9,32 @@ module.exports = (req, res, next) => {
   const outputJpg = path.join(IMAGES_DIR, `imageAffiche${numberOfImage}.jpg`);
   const finalPath = path.join(FILES_DIR, nameOfFile);
 
+  console.log(`[upload] fichier reçu : ${nameOfFile} → slot ${numberOfImage}`);
+
   fs.copyFile(uploadedPath, outputJpg, (copyErr) => {
-    if (copyErr) return res.status(500).json({ error: copyErr.message });
+    if (copyErr) {
+      console.error(`[upload] erreur copie vers ${outputJpg} :`, copyErr.message);
+      return res.status(500).json({ error: copyErr.message });
+    }
+    console.log(`[upload] image sauvegardée → ${outputJpg}`);
 
     fs.rename(uploadedPath, finalPath, (renameErr) => {
-      if (renameErr) return res.status(500).json({ error: renameErr.message });
+      if (renameErr) {
+        console.error(`[upload] erreur renommage vers ${finalPath} :`, renameErr.message);
+        return res.status(500).json({ error: renameErr.message });
+      }
+      console.log(`[upload] fichier original déplacé → ${finalPath}`);
 
-      const dbPath = path.join(DB_DIR, "images-display.txt");
-      let objectImage = JSON.parse(fs.readFileSync(dbPath));
-      objectImage.imageDisplay[numberOfImage - 1] = nameOfFile;
-      fs.writeFileSync(dbPath, JSON.stringify(objectImage, null, 2));
+      try {
+        const dbPath = path.join(DB_DIR, "images-display.txt");
+        let objectImage = JSON.parse(fs.readFileSync(dbPath));
+        objectImage.imageDisplay[numberOfImage - 1] = nameOfFile;
+        fs.writeFileSync(dbPath, JSON.stringify(objectImage, null, 2));
+        console.log(`[upload] DB mise à jour : slot ${numberOfImage} = ${nameOfFile}`);
+      } catch (dbErr) {
+        console.error("[upload] erreur mise à jour DB :", dbErr.message);
+        return res.status(500).json({ error: dbErr.message });
+      }
 
       next();
     });

--- a/package.json
+++ b/package.json
@@ -14,7 +14,6 @@
   "license": "ISC",
   "dependencies": {
     "@hebcal/core": "^3.42.0",
-    "@napi-rs/canvas": "^0.1.98",
     "cors": "^2.8.5",
     "dotenv": "^16.0.1",
     "electron-log": "^5.4.3",

--- a/public/myApp.js
+++ b/public/myApp.js
@@ -1,3 +1,5 @@
+import * as pdfjsLib from "/pdfjs/pdf.mjs";
+pdfjsLib.GlobalWorkerOptions.workerSrc = "/pdfjs/pdf.worker.mjs";
 
 // POST RELOAD PAGE
 
@@ -238,37 +240,63 @@ function addEvent(formPDF, loaderPdf, inputFile) {
   });
 }
 
-function allPDF(files, loaderPdf) {
+async function fileToJpegBlob(file) {
+  const canvas = document.createElement("canvas");
+  const ctx = canvas.getContext("2d");
+
+  if (file.type === "application/pdf") {
+    const data = new Uint8Array(await file.arrayBuffer());
+    const pdf = await pdfjsLib.getDocument({ data }).promise;
+    const page = await pdf.getPage(1);
+    const viewport = page.getViewport({ scale: 150 / 72 });
+    canvas.width = viewport.width;
+    canvas.height = viewport.height;
+    await page.render({ canvasContext: ctx, viewport }).promise;
+  } else {
+    const img = await createImageBitmap(file);
+    canvas.width = img.width;
+    canvas.height = img.height;
+    ctx.drawImage(img, 0, 0);
+  }
+
+  return new Promise((resolve) => canvas.toBlob(resolve, "image/jpeg", 0.92));
+}
+
+async function allPDF(files, loaderPdf) {
   let formParent = loaderPdf.parentNode;
-  // console.log(formParent);
   files = document.getElementById(files);
-  // console.log(files.files[0]);
+  const file = files.files[0];
+  const numberOfImage = files.id.substr(-1);
+
+  let jpegBlob;
+  try {
+    jpegBlob = await fileToJpegBlob(file);
+  } catch (err) {
+    loaderPdf.setAttribute("id", "loader-1");
+    erreur(loaderPdf);
+    return;
+  }
+
+  const baseName = file.name.replace(/\.[^.]+$/, "");
   const formData = new FormData();
-  formData.append("files", files.files[0]);
-  formData.append("nameOfFile", files.files[0].name);
-  formData.append("numberOfImage", files.id.substr(-1));
-  fetch("/admin/upload_pdf", {
-    method: "POST",
-    body: formData,
-    headers: {
-      //   "Content-Type":'undefined'
-    },
-  })
+  formData.append("files", jpegBlob, baseName + ".jpg");
+  formData.append("nameOfFile", file.name);
+  formData.append("numberOfImage", numberOfImage);
+
+  fetch("/admin/upload_pdf", { method: "POST", body: formData })
     .then((res) => {
-      console.log(res);
       if (!res.ok) {
         loaderPdf.setAttribute("id", "loader-1");
         erreur(loaderPdf);
       } else {
         validator(loaderPdf);
-        formParent.children[3].innerHTML = files.files[0].name;
+        formParent.children[3].innerHTML = file.name;
       }
       reloadPage(urlReload, bodyReload);
     })
     .catch((err) => {
       loaderPdf.setAttribute("id", "loader-1");
       erreur(loaderPdf);
-      return "Error occured", err;
     });
 }
 

--- a/public/myApp.js
+++ b/public/myApp.js
@@ -241,22 +241,26 @@ function addEvent(formPDF, loaderPdf, inputFile) {
 }
 
 async function fileToJpegBlob(file) {
+  console.log(`[conversion] début : ${file.name} (${file.type})`);
   const canvas = document.createElement("canvas");
   const ctx = canvas.getContext("2d");
 
   if (file.type === "application/pdf") {
     const data = new Uint8Array(await file.arrayBuffer());
     const pdf = await pdfjsLib.getDocument({ data }).promise;
+    console.log(`[conversion] PDF chargé : ${pdf.numPages} page(s)`);
     const page = await pdf.getPage(1);
     const viewport = page.getViewport({ scale: 150 / 72 });
     canvas.width = viewport.width;
     canvas.height = viewport.height;
     await page.render({ canvasContext: ctx, viewport }).promise;
+    console.log(`[conversion] page 1 rendue (${canvas.width}×${canvas.height}px)`);
   } else {
     const img = await createImageBitmap(file);
     canvas.width = img.width;
     canvas.height = img.height;
     ctx.drawImage(img, 0, 0);
+    console.log(`[conversion] image rendue (${canvas.width}×${canvas.height}px)`);
   }
 
   return new Promise((resolve) => canvas.toBlob(resolve, "image/jpeg", 0.92));
@@ -268,10 +272,14 @@ async function allPDF(files, loaderPdf) {
   const file = files.files[0];
   const numberOfImage = files.id.substr(-1);
 
+  console.log(`[upload] fichier sélectionné : ${file.name}, slot ${numberOfImage}`);
+
   let jpegBlob;
   try {
     jpegBlob = await fileToJpegBlob(file);
+    console.log(`[upload] blob JPEG prêt : ${jpegBlob.size} bytes`);
   } catch (err) {
+    console.error(`[upload] erreur conversion :`, err);
     loaderPdf.setAttribute("id", "loader-1");
     erreur(loaderPdf);
     return;
@@ -286,15 +294,18 @@ async function allPDF(files, loaderPdf) {
   fetch("/admin/upload_pdf", { method: "POST", body: formData })
     .then((res) => {
       if (!res.ok) {
+        console.error(`[upload] erreur serveur : HTTP ${res.status}`);
         loaderPdf.setAttribute("id", "loader-1");
         erreur(loaderPdf);
       } else {
+        console.log(`[upload] succès → imageAffiche${numberOfImage}.jpg`);
         validator(loaderPdf);
         formParent.children[3].innerHTML = file.name;
       }
       reloadPage(urlReload, bodyReload);
     })
     .catch((err) => {
+      console.error("[upload] erreur réseau :", err);
       loaderPdf.setAttribute("id", "loader-1");
       erreur(loaderPdf);
     });

--- a/views/index.html
+++ b/views/index.html
@@ -163,5 +163,14 @@
     </div>
   </div>
 </body>
+  <script>
+    // Polyfill Map.prototype.getOrInsertComputed (Chrome 129+) absent d'Electron 19 (Chromium 102)
+    if (!Map.prototype.getOrInsertComputed) {
+      Map.prototype.getOrInsertComputed = function (key, fn) {
+        if (!this.has(key)) this.set(key, fn(key));
+        return this.get(key);
+      };
+    }
+  </script>
   <script type="module" src="../public/myApp.js"></script>
 </html>

--- a/views/index.html
+++ b/views/index.html
@@ -163,5 +163,5 @@
     </div>
   </div>
 </body>
-  <script src="../public/myApp.js"></script>
+  <script type="module" src="../public/myApp.js"></script>
 </html>


### PR DESCRIPTION
$(cat <<'EOF'
## Problème

`@napi-rs/canvas` est un module natif Rust qui échouait sur Windows lors du build/run. Il était utilisé dans `gmshell-config.js` pour convertir les PDF et images en JPEG côté serveur Node.

## Solution

Déplacer toute la conversion côté **browser** (Chromium embarqué dans Electron) : zéro dépendance native, même comportement sur Windows et Linux.

## Changements

- **`app.js`** — expose `node_modules/pdfjs-dist/build` via `/pdfjs` (express.static)
- **`middleware/gmshell-config.js`** — suppression de `@napi-rs/canvas` + `pdfjs-dist` côté Node ; le middleware reçoit maintenant un blob JPEG déjà converti et se contente de le copier dans `images/` et de mettre à jour `images-display.txt`
- **`public/myApp.js`** — ajout de l'import ES module `pdfjs-dist` ; nouvelle fonction `fileToJpegBlob()` qui gère PDF (render page 1 via PDF.js) et images (drawImage) sur un Canvas natif browser → `toBlob('image/jpeg')`
- **`views/index.html`** — `<script type="module">` pour supporter l'import ES
- **`package.json`** — suppression de `@napi-rs/canvas`

## Test

1. Uploader un PDF dans l'admin → l'image s'affiche dans `/shoul`
2. Uploader un PNG/JPG → même résultat
3. Vérifier que `images/imageAffiche{N}.jpg` est bien créé côté serveur

https://claude.ai/code/session_01P2QWKsFCoQRYBuWnhYv5zy
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_01P2QWKsFCoQRYBuWnhYv5zy)_